### PR TITLE
Typo fixes and (optional) addition of Aliases: to YAML front matter of Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,8 @@ Once you are in the directory, run `bash bg2obs.sh`. This will run the bash scri
 Within the `bg2obs.sh` file you have the options to include headers and set the words of Jesus to bold. By default, both options are set to `false`. You may also set an option to add an alias to the chapter in the YAML front matter at the top of each chapter's Markdown file. The alias creates a more user-friendly version of the chapter link (e.g, "Genesis 1") in your notes. The `aliases` option is set to `false` by default.
 
 ### 3. Format the text in a text editor
-We will need to format the output to work well in Obsidian.
-1. Open [Atom](https://atom.io/) (or the like).
-2. Open the `Scripture` folder with `File > Add Project Folder…` (or `Shift + Command + O`
-3. Open project-wide search with `Shift + Command + F`
 
-Next up we are going to run two [Regex](https://en.wikipedia.org/wiki/Regular_expression)-searches to find and replace in our whole project.
-1. Enable Regex. Click the `.*` Icon.
-2. Run the first search. This clears unnecessary headers:
-* Find: `#.*(#####\D[1]\D)`
-* Replace: `#$1`
-* file: `*.md`
-3. Run the second search. This formats verses into h6:
-* Find: `######\s([0-9]\s|[0-9][0-9]\s|[0-9][0-9][0-9]\s)`
-* Replace: `\n\n###### v$1\n`
-* file: `*.md`
-(Some crossreferences are sometimes still included, run `\<crossref intro.*crossref\>` to delete.)
-
-Note: In [BBEdit](https://www.barebones.com/products/bbedit/), the replacement strings should use `\1` instead of `$1`.
+Some crossreferences are sometimes still included, run `\<crossref intro.*crossref\>` to delete.
 
 **There you go!** Now, just move the "Scripture" folder into your Obsidian vault. You can use the provided `The Bible.md` file as an overview file.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BibleGateway-to-Obsidian
 This script adapts [jgclark's wonderful BibleGateway-to-Markdown](https://github.com/jgclark/BibleGateway-to-Markdown) script to export for use in [Obsidian](https://obsidian.md/). It accompanies a [Bible Study in Obsidian Kit](https://forum.obsidian.md/t/bible-study-in-obsidian-kit-including-the-bible-in-markdown/12503?u=selfire) that gets you hands-on with using Scripture in your personal notes.
 
-What the script does is fetch the text from [Bible Gateway](https://www.biblegateway.com/) and save it as formatted markdown file. Each chapter is saved as one file and navigation between files as well as a book-file is automatically created. All of the chapter files of a book are saved in it's numbered folder.
+What the script does is fetch the text from [Bible Gateway](https://www.biblegateway.com/) and save it as formatted markdown file. Each chapter is saved as one file and navigation between files as well as a book-file is automatically created. All of the chapter files of a book are saved in its numbered folder.
 
 This script is intended to be as simple as possible to use, even if you have no idea about Scripting. If you have any questions, please reach out to me either on github or Discord (`selfire#3095`).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Once you are in the directory, run `bash bg2obs.sh`. This will run the bash scri
 
 `NOTE`: In this directory, a folder called `Scripture` with subfolders like `01 - Genesis`, `02 - Exodus` and so on will be created.
 
-Within the `bg2obs.sh` file you have the options to include headers and set the words of Jesus to bold. By default, both options are set to `false`.
+Within the `bg2obs.sh` file you have the options to include headers and set the words of Jesus to bold. By default, both options are set to `false`. You may also set an option to add an alias to the chapter in the YAML front matter at the top of each chapter's Markdown file. The alias creates a more user-friendly version of the chapter link (e.g, "Genesis 1") in your notes. The `aliases` option is set to `false` by default.
 
 ### 3. Format the text in a text editor
 We will need to format the output to work well in Obsidian.
@@ -54,6 +54,8 @@ Next up we are going to run two [Regex](https://en.wikipedia.org/wiki/Regular_ex
 * Replace: `\n\n###### v$1\n`
 * file: `*.md`
 (Some crossreferences are sometimes still included, run `\<crossref intro.*crossref\>` to delete.)
+
+Note: In [BBEdit](https://www.barebones.com/products/bbedit/), the replacement strings should use `\1` instead of `$1`.
 
 **There you go!** Now, just move the "Scripture" folder into your Obsidian vault. You can use the provided `The Bible.md` file as an overview file.
 

--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -29,7 +29,7 @@ book_counter_max=66 # Setting the max amount to 66, since there are 66 books we 
 declare -a bookarray # Declaring the Books of the Bible as a list
 bookarray=(Genesis Exodus Leviticus Numbers Deuteronomy Joshua Judges Ruth "1 Samuel" "2 Samuel" "1 Kings" "2 Kings" "1 Chronicles" "2 Chronicles" Ezra Nehemiah Esther Job Psalm Proverbs Ecclesiastes "Song of Solomon" Isaiah Jeremiah Lamentations Ezekiel Daniel Hosea Joel Amos Obadiah Jonah Micah Nahum Habakkuk Zephaniah Haggai Zechariah Malachi Matthew Mark Luke John Acts
 Romans "1 Corinthians" "2 Corinthians" Galatians Ephesians Philippians Colossians "1 Thessalonians" "2 Thessalonians" "1 Timothy" "2 Timothy" Titus Philemon Hebrews James "1 Peter" "2 Peter" "1 John" "2 John" "3 John" Jude Revelation)
-x
+
 # Book chapter list
 declare -a lengtharray # Declaring amount of chapters in each book
 lengtharray=(50 40 27 36 34 24 21 4 31 24 22 25 29 36 10 13 10 42 150 31 12 8 66 52 5 48 12 14 3 9 1 4 7 3 3 3 2 14 4 28 16 24 21 28 16 16 13 6 6 4 4 5 3 6 4 3 1 13 5 5 3 5 1 1 1 22)

--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -110,7 +110,7 @@ filename=${export_prefix}$export_number # Setting the filename
   title="# ${book} ${chapter}"
 
   # Navigation format
-  export="${title}\n\n$navigation\n***\n\n$text\n\n***\n$navigation"
+  export="---\nAliases: [${book} ${chapter}]\n---\n${title}\n\n$navigation\n***\n\n$text\n\n***\n$navigation"
 
 
   # Export

--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -38,7 +38,7 @@ declare -a abbarray # Delaring the abbreviations for each book. You can adapt if
 abbarray=(Gen Exod Lev Num Deut Josh Judg Ruth "1 Sam" "2 Sam" "1 Kings" "2 Kings" "1 Chron" "2 Chron" Ezr Neh Esth Job Ps Prov Eccles Song Isa Jer Lam Ezek Dan Hos Joel Am Obad Jonah Micah Nah Hab Zeph Hag Zech Mal Matt Mark Luke John Acts Rom "1 Cor" "2 Cor" Gal Ephes Phil Col "1 Thess" "2 Thess" "1 Tim" "2 Tim" Titus Philem Heb James "1 Pet" "2 Pet" "1 John" "2 John" "3 John" Jude Rev)
 
 
- # Cycling through the book counter, setting which book and it's maxchapter
+ # Cycling through the book counter, setting which book and its maxchapter
   for ((book_counter=0; book_counter <= book_counter_max; book_counter++))
   do
 
@@ -65,12 +65,12 @@ abbarray=(Gen Exod Lev Num Deut Josh Judg Ruth "1 Sam" "2 Sam" "1 Kings" "2 King
 filename=${export_prefix}$export_number # Setting the filename
 
 # Navigation in the note
-  if (( ${prev_chapter} < 10 )); then # Turning singe into double digit numbers
+  if (( ${prev_chapter} < 10 )); then # Turning single into double digit numbers
     #statements
     prev_chapter="0${prev_chapter}"
   fi
 
-  if (( ${next_chapter} < 10 )); then # Turning singe into double digit numbers
+  if (( ${next_chapter} < 10 )); then # Turning single into double digit numbers
     #statements
     next_chapter="0${next_chapter}"
   fi
@@ -94,13 +94,13 @@ filename=${export_prefix}$export_number # Setting the filename
   fi
 
   if ${boldwords} -eq "true" && ${headers} -eq "false"; then
-    text=$(ruby bg2md.rb -e -c -b -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
+    text=$(ruby bg2md.rb -e -c -b -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod' script
   elif ${boldwords} -eq "true" && ${headers} -eq "true"; then
-    text=$(ruby bg2md.rb -c -b -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
+    text=$(ruby bg2md.rb -c -b -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod' script
   elif ${boldwords} -eq "false" && ${headers} -eq "true"; then
-    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
+    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod' script
   else
-    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod script'
+    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod' script
   fi
 
 
@@ -129,7 +129,7 @@ filename=${export_prefix}$export_number # Setting the filename
 
   folder_name="${actual_num} - ${book}" # Setting the folder name
 
-  # Creating a folder for the book of the Bible it not existing, otherwise moving new file into existing folder
+  # Creating a folder for the book of the Bible if it doesn't exist, otherwise moving new file into existing folder
   mkdir -p "./Scripture (${translation})/${folder_name}"; mv "${filename}".md './Scripture ('"${translation}"')/'"${folder_name}"
 
 

--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -20,6 +20,7 @@
 translation="WEB" # Set translation
 boldwords="false" # Set 'true' for bolding words of Jesus
 headers="false" # Set 'true' for including editorial headers
+aliases="false" # Set 'true' to create an alias in the YAML front matter to a chapter title (e.g., 'Genesis 1')
 
 book_counter=0 # Setting the counter to 0
 book_counter_max=66 # Setting the max amount to 66, since there are 66 books we want to import
@@ -110,8 +111,12 @@ filename=${export_prefix}$export_number # Setting the filename
   title="# ${book} ${chapter}"
 
   # Navigation format
-  export="---\nAliases: [${book} ${chapter}]\n---\n${title}\n\n$navigation\n***\n\n$text\n\n***\n$navigation"
-
+  export="${title}\n\n$navigation\n***\n\n$text\n\n***\n$navigation"
+  if ${aliases} -eq "true"; then
+    alias="---\nAliases: [${book} ${chapter}]\n---\n" # Add other aliases or 'Tags:' here if desired. Make sure to follow proper YAML format.
+    export="${alias}${export}"
+  fi
+  
 
   # Export
   echo -e $export >> "$filename.md"

--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -148,6 +148,7 @@ done # End of the book exporting loop
 
   done
 
+  
   #----------------------------------------------------------------------------------
   # The Output of this text needs to be formatted slightly to fit with use in Obsidian
   # Enable Regex and run find and replace:
@@ -160,3 +161,19 @@ done # End of the book exporting loop
       # Replace: \n\n$1\n
       # file: *.md
   #----------------------------------------------------------------------------------
+
+# Not sure if the comments above are still needed, so leaving them for now.
+
+# Tidy up the Markdown files by removing unneeded headers and separating the verses
+# with some blank space and an H6-level verse number.
+#
+# Using a perl one-liner here in order to help ensure that this works across platforms
+# since the sed utility works differently on macOS and Linux variants. The perl should
+# work consistently.
+
+echo "Cleaning up the Markdown files..."
+# Clear unnecessary headers
+find . -name "*.md" -print0 | xargs -0 perl -pi -e 's/#.*(#####\D[1]\D)/#$1/g'
+
+# Format verses into H6 headers
+find . -name "*.md" -print0 | xargs -0 perl -pi -e 's/######\s([0-9]\s|[0-9][0-9]\s|[0-9][0-9][0-9]\s)/\n\n###### v$1\n/g'


### PR DESCRIPTION
@selfire1, thanks for this handy script! I'm a brand-new Obsidian user and was able to use this script to add the Bible text to my Obsidian vault.

After playing with the script a few times, I found a few things to tweak if you're open to this pull request. (Please note, this is my first ever pull request to another developer. I'm not entirely sure what I'm doing, and it's possible that I've committed a _faux pas_ somewhere, so please forgive me if that's the case.)

Changes included in this pull request:

* Some typo fixes in the code and README.
* Removed a stray `x` character in the script that was causing XQuartz to crash on my Big Sur macOS system.
* Added the option to utilize the new YAML front matter feature in recent versions of Obsidian to add an alias to a more user-friendly version of each chapter name. Instead of needing to link with something like `[[Gen-01]]`, you can now link to `[[Genesis 1]]` using the alias which produces actual Markdown like this: `[[Gen-01|Genesis 1]]`. It looks better to my eye.
* Added two perl one-liners to eliminate the need to manually do the search and replace in Atom or another text editor to tidy up the Markdown. I tried doing it in `sed`, but the versions of `sed` on macOS and Linux are quite different, and I didn't think it would be easy to create something that would work across platforms. Using the perl script should make that a lot better, and it's all transparent to the user. The only potential downside is that it would require perl to be installed. I'm not sure if it is on current Windows systems.

Let me know if you have any questions. Perhaps I should have broken these down into separate PRs, but I wasn't sure of the proper protocol.

All my best,
Tim