### PR TITLE
Update bg2obs.sh

### DIFF
--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -132,13 +132,13 @@ filename=${export_prefix}$chapter # Setting the filename
   fi
 
   if ${boldwords} -eq "true" && ${headers} -eq "false"; then
-    text=$(ruby bg2md.rb -e -c -b -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod' script
+    text=$(ruby bg2md.rb -e -c -b -f -l -r -v "${translation}" "${book}" ${chapter}) # This calls the 'bg2md_mod' script
   elif ${boldwords} -eq "true" && ${headers} -eq "true"; then
-    text=$(ruby bg2md.rb -c -b -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod' script
+    text=$(ruby bg2md.rb -c -b -f -l -r -v "${translation}" "${book}" ${chapter}) # This calls the 'bg2md_mod' script
   elif ${boldwords} -eq "false" && ${headers} -eq "true"; then
-    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod' script
+    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" "${book}" ${chapter}) # This calls the 'bg2md_mod' script
   else
-    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" ${book} ${chapter}) # This calls the 'bg2md_mod' script
+    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" "${book}" ${chapter}) # This calls the 'bg2md_mod' script
   fi
 
 


### PR DESCRIPTION
I received the following error in all chapter .md files of books that start with a digit: Error: could not parse data from BibleGateway: please check your usage, and if still a problem, please raise an issue on GitHub.

Added Quotation Marks around the ${book} variable resolved the issue when calling the Ruby script.

So far all my translations are working fine. I havent found any other bugs due to the change.