### PR TITLE
Update bg2obs- Moved Quotation Mark to end of Chapter

### DIFF
--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -132,13 +132,13 @@ filename=${export_prefix}$chapter # Setting the filename
   fi
 
   if ${boldwords} -eq "true" && ${headers} -eq "false"; then
-    text=$(ruby bg2md.rb -e -c -b -f -l -r -v "${translation}" "${book}" ${chapter}) # This calls the 'bg2md_mod' script
+    text=$(ruby bg2md.rb -e -c -b -f -l -r -v "${translation}" "${book} ${chapter}") # This calls the 'bg2md_mod' script
   elif ${boldwords} -eq "true" && ${headers} -eq "true"; then
-    text=$(ruby bg2md.rb -c -b -f -l -r -v "${translation}" "${book}" ${chapter}) # This calls the 'bg2md_mod' script
+    text=$(ruby bg2md.rb -c -b -f -l -r -v "${translation}" "${book} ${chapter}") # This calls the 'bg2md_mod' script
   elif ${boldwords} -eq "false" && ${headers} -eq "true"; then
-    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" "${book}" ${chapter}) # This calls the 'bg2md_mod' script
+    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" "${book} ${chapter}") # This calls the 'bg2md_mod' script
   else
-    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" "${book}" ${chapter}) # This calls the 'bg2md_mod' script
+    text=$(ruby bg2md.rb -e -c -f -l -r -v "${translation}" "${book} ${chapter}") # This calls the 'bg2md_mod' script
   fi
 
 


### PR DESCRIPTION
I tested the code again, placing the quotation mark after the book name returns the 1st chapter every time. So I moved it to after the chapter, and I exported the AMP and NKJV successfully. Maybe test on your side as well before merging.