### PR TITLE
Fix the Book with Space in Name Issue

### DIFF
--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -217,8 +217,9 @@ for ((book_index=0; book_index<66; book_index++)); do
       bg2md_flags="${bg2md_flags} -e"
     fi
 
+    book_no_spaces=$(echo "$book" | sed 's/ //g')
     # Use the bg2md script to read chapter contents
-    chapter_content=$(ruby bg2md.rb $bg2md_flags -v $ARG_VERSION $book$chapter)
+    chapter_content=$(ruby bg2md.rb $bg2md_flags -v $ARG_VERSION $book_no_spaces$chapter)
 
     # Delete unwanted headers from chapter content
     chapter_content=$(echo $chapter_content | sed 's/^(.*?)v1/v1/')


### PR DESCRIPTION
There was a bug that I and other people faced where a chapter with space in name did not receive back any data. The issue is not with this project, but was probably caused by a change in the ruby project that we make us of. 

The solution I found was to remove spaces in the names before sending them to that code and it did work well. More people have tried it and it worked, as per [this](https://github.com/selfire1/BibleGateway-to-Obsidian/issues/43#issuecomment-1742557621) comment. 