### PR TITLE
Use correct syntax for comparing numbers

### DIFF
--- a/bg2obs.sh
+++ b/bg2obs.sh
@@ -227,20 +227,20 @@ for ((book_index=0; book_index<66; book_index++)); do
     # Use original header/footer navigation if another method isn't specified
     if [[ $ARG_BC_INLINE == "false" && $ARG_BC_YAML == "false" ]]; then
       navigation="[[$book]]"
-      if [[ $chapter > 1 ]]; then
+      if [[ $chapter -gt 1 ]]; then
         navigation="[[$prev_file|← $book $prev_chapter]] | $navigation"
       fi
-      if [[ $chapter < $last_chapter ]]; then
+      if [[ $chapter -lt $last_chapter ]]; then
         navigation="$navigation | [[$next_file|$book $next_chapter →]]"
       fi
 
     # Navigation with INLINE BREADCRUMBS ENABLED
     elif [[ $ARG_BC_INLINE == "true" ]] ; then
       navigation="(up:: [[$book]])"
-      if [[ $chapter > 1 ]]; then
+      if [[ $chapter -gt 1 ]]; then
         navigation="(previous:: [[$prev_file|← $book $prev_chapter]]) | $navigation"
       fi
-      if [[ $chapter < $last_chapter ]]; then
+      if [[ $chapter -lt $last_chapter ]]; then
         navigation="$navigation | (next:: [[$next_file|$book $next_chapter →]])"
       fi
     fi
@@ -257,10 +257,10 @@ for ((book_index=0; book_index<66; book_index++)); do
     if [[ $ARG_BC_YAML == "true" ]]; then
       # create YAML breadcrumbs
       bc_yaml="\nup: ['$book']"
-      if [[ $chapter > 1 ]]; then
+      if [[ $chapter -gt 1 ]]; then
         bc_yaml="\nprevious: ['$prev_file']$bc_yaml"
       fi
-      if [[ $chapter < $last_chapter ]]; then
+      if [[ $chapter -lt $last_chapter ]]; then
         bc_yaml="$bc_yaml\nnext: ['$next_file']"
       fi
 


### PR DESCRIPTION
I noticed that some of the chapters didn't have the links to the next chapter. I analyzed the chapters that did versus the chapters that didn't and came across the annoying thing about some number sorting operations. For example, 10 is greater than 1 but also greater than 2 because the system is first comparing the first numbers and then the second.

One way to override this is to add 0 before 1, 2, 3, etc. but that's not really reader-friendly. However, I did find a way to do it (thanks Stackflow). Bash script documentation says that the operators -gt and -lt are preferred to > and < unless you're using parentheses instead of brackets and some other blah blah blah stuff.

Anyway, I fixed it on my side so I thought it wouldn't hurt to send a pull request to help anyone else who came across that issue.